### PR TITLE
招待ページに家族の一覧を表示させた

### DIFF
--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -3,5 +3,6 @@
 class FamiliesController < ApplicationController
   def show
     @family = Family.find(current_user.family_id)
+    @users = User.where(family_id: current_user.family_id).where.not(id: current_user.id).order(created_at: :desc)
   end
 end

--- a/app/views/families/show.html.slim
+++ b/app/views/families/show.html.slim
@@ -7,5 +7,15 @@
     br
     | 以下のURLからログインすると、こどもの情報を家族で共有することができます。
 
-  .py-3.px-4.w-full.bg-orange-50.rounded-md.text-sm
+  .mb-10.py-3.px-4.w-full.bg-orange-50.rounded-md.text-sm
     p #{request.protocol}#{request.host}/welcome?invitation_token=#{@family.invitation_token}
+
+  .mx-2
+    h2.mb-6.pb-1.border-b-2.border-slate-200
+      | 家族の一覧
+    - if @users.empty?
+      p.text-sm
+        | こどもの情報を共有している家族はいません。
+    - else
+      #users
+      = render @users

--- a/app/views/users/_user.html.slim
+++ b/app/views/users/_user.html.slim
@@ -1,0 +1,2 @@
+p.text-sm
+  = user.name


### PR DESCRIPTION
## Issue
- #101 

## 修正内容
招待ページの下部に既に追加済みの家族の一覧を表示させた
### 既に登録済みの家族がいる場合の表示
![image](https://github.com/siroemk/cotomemory/assets/31835314/ba9dbe8c-aeea-475a-b1e1-2416e4145d23)

### 家族がいない場合の表示
![image](https://github.com/siroemk/cotomemory/assets/31835314/03c65c75-5783-4215-9e62-d7d8202e0952)