### PR TITLE
こどもの一覧ページにこどもの追加フォームへのリンクををつけた

### DIFF
--- a/app/views/children/index.html.slim
+++ b/app/views/children/index.html.slim
@@ -7,3 +7,7 @@
 
   - if @children.empty?
     | こどもの情報が登録されていません。
+
+  .text-right.text-sm.mt-4
+    = link_to 'こどもを追加する', new_child_path,
+      class: 'font-bold text-slate-600 cursor-pointer'


### PR DESCRIPTION
## Issue
- #122 
こどもの一覧ページにこどもの情報を追加するページへのリンクがあると使いやすそうなので、追加ボタンをつけた。
## 修正前
![image](https://github.com/siroemk/cotomemory/assets/31835314/a3dfb6b8-215c-4686-812f-01b308cda8e6)

## 修正後
![image](https://github.com/siroemk/cotomemory/assets/31835314/978bca37-6378-4deb-b172-e15f8b554379)
