### PR TITLE
退会したユーザーが登録した名言には「退会したユーザー」と表示する

### DIFF
--- a/app/views/quotes/_quote.html.slim
+++ b/app/views/quotes/_quote.html.slim
@@ -2,7 +2,6 @@
   .border-b.py-4
     p = quote.content
     p.text-sm.text-slate-500 = l quote.created_at, format: :long
-    p.text-sm.text-slate-500 = quote.user.name
     = link_to '編集', edit_quote_path(quote), data: { turbo_frame: 'edit_quote' }, class: 'text-sm text-slate-500 cursor-pointer'
     .hidden.fixed.overlay.top-0.left-0.w-screen.h-screen.bg-gray-700.bg-opacity-50.z-10 data-controller='modal' data-modal-target='modal' data-action='turbo:frame-load->modal#open turbo:submit-end->modal#close'
       .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-1/2.w-max.h-max.bg-white.p-10.rounded-lg

--- a/app/views/quotes/show.html.slim
+++ b/app/views/quotes/show.html.slim
@@ -1,5 +1,12 @@
 = render @quote
 
+p.text-xs.text-slate-500.text-right
+  | 記録：
+  - if @quote.user.nil?
+    | 退会済みのユーザー
+  - else
+    = @quote.user.name
+
 #comments
   = render partial: 'comments/comment', collection: @comments, as: :comment
 


### PR DESCRIPTION
## Issue
- #87 

## 修正後
![image](https://github.com/siroemk/cotomemory/assets/31835314/a9559e4a-a08e-4f83-a55a-12f7cebc0ee2)
