### PR TITLE
名言が登録されていない時の表示を追加した

### DIFF
--- a/app/views/quotes/index.html.slim
+++ b/app/views/quotes/index.html.slim
@@ -4,7 +4,23 @@
 
   - if @quotes.empty?
     #first_message
-      | 最初の名言を登録しよう！
+      .py-4.mb-2.bg-white.rounded.h-full
+        p.text-center.mt-4.mb-6
+          | まだ名言が登録されていません。
+          br
+          | 最初の名言を登録しよう！
+
+        div data-controller='modal'
+          .text-center.mb-6
+            = link_to '登録する', new_quote_path, data: { turbo_frame: 'new_quote' },
+              class: 'bg-primary hover:bg-orange-300 py-3 px-16 mb-4 rounded-full text-white font-bold cursor-pointer'
+          .hidden.fixed.overlay.top-0.left-0.w-screen.h-screen.bg-gray-300.bg-opacity-70.z-20  data-modal-target='modal' data-action='turbo:frame-load->modal#open turbo:submit-end->modal#close'
+            .absolute.top-1/2.left-1/2.-translate-x-1/2.-translate-y-2/3.w-96.h-96.bg-white.p-6.rounded-lg
+              .text-right
+                button.text-3xl.text-slate-500.mb-2 data-action='click->modal#close'
+                  | ×
+                = turbo_frame_tag 'new_quote'
+        = image_tag 'read_book.png', alt: '本を読んでいるこどもの画像', class: 'w-3/4 m-auto max-w-screen-sm'
 
   div data-controller='modal'
     .fixed.bottom-14.left-1/2.-translate-x-1/2.-translate-y-1/2.z-10

--- a/spec/system/quotes_spec.rb
+++ b/spec/system/quotes_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'Quotes', type: :system do
     fill_in 'child[name]', with: '花子'
     click_on '保存する'
 
-    click_link nil, href: new_quote_path
+    click_on '登録する'
     fill_in 'quote[content]', with: 'テストの名言です'
     click_on '登録する'
     expect(current_path).to eq quotes_path


### PR DESCRIPTION
## Issue
- #112 

## 修正後
名言がひとつも登録されていない時の表示
<img width="661" alt="image" src="https://github.com/siroemk/cotomemory/assets/31835314/17511e33-bf87-46c1-963e-e7bfecc372cd">
