### PR TITLE
こどものフォームで誕生日の年の選択肢を現在の年からスタートするように設定した

### DIFF
--- a/app/views/children/_form.html.slim
+++ b/app/views/children/_form.html.slim
@@ -1,9 +1,6 @@
 = form_with model: @child, locale: true do |f|
-  - if @child.errors.any?
-    ul
-      - @child.errors.full_messages.each do |message|
-        li.text-rose-600.text-sm.mb-1
-          = message
+  = render 'shared/error_messages', object: f.object
+
   .mb-2
     = f.label :name,
       class: 'pl-2 py-3 text-sm font-medium'

--- a/app/views/children/_form.html.slim
+++ b/app/views/children/_form.html.slim
@@ -5,13 +5,13 @@
         li.text-rose-600.text-sm.mb-1
           = message
   .mb-2
-    = f.label :こどもの名前,
+    = f.label :name,
       class: 'pl-2 py-3 text-sm font-medium'
   .mb-6
     = f.text_field :name,
       class: 'py-3 px-4 w-full border-gray-200 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500'
   .mb-2
-    = f.label :こどもの誕生日,
+    = f.label :date_of_birth,
       class: 'pl-2 py-3 text-sm font-medium'
   .mb-6
     = f.date_select :date_of_birth, { use_month_numbers: true, start_year: Time.zone.now.year, end_year: 2000 },

--- a/app/views/children/_form.html.slim
+++ b/app/views/children/_form.html.slim
@@ -14,7 +14,7 @@
     = f.label :こどもの誕生日,
       class: 'pl-2 py-3 text-sm font-medium'
   .mb-6
-    = f.date_select :date_of_birth, { use_month_numbers: true },
+    = f.date_select :date_of_birth, { use_month_numbers: true, start_year: Time.zone.now.year, end_year: 2000 },
       class: 'py-3 px-4 w-1/4 border-gray-200 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500'
   .mb-6.text-center
     = f.submit '保存する',

--- a/app/views/children/new.html.slim
+++ b/app/views/children/new.html.slim
@@ -4,6 +4,8 @@
   h1.mb-6.text-center.font-semibold
     | こどもの情報を登録する
   p.mb-8.text-center.text-xs
+    | 名言を登録するためにこどもの情報を追加しよう。
+    br
     | こどもの情報は登録後も設定から変更できます。
 
     = render 'form', child: @child


### PR DESCRIPTION
こどものフォームで誕生日の年の選択肢に未来の年も表示されていたので、現在の年からスタートするように設定しました。


## 変更前
![image](https://github.com/siroemk/cotomemory/assets/31835314/b29ae2dd-65a1-4625-9762-1ef5564570ce)

## 変更後
![image](https://github.com/siroemk/cotomemory/assets/31835314/734dc870-4f63-4e6c-928b-7d8d41ae3423)
