### PR TITLE
families_controllerでActiveRecordを活用できそうな箇所の修正

### DIFF
--- a/app/controllers/families_controller.rb
+++ b/app/controllers/families_controller.rb
@@ -3,6 +3,6 @@
 class FamiliesController < ApplicationController
   def show
     @family = Family.find(current_user.family_id)
-    @users = User.where(family_id: current_user.family_id).where.not(id: current_user.id).order(created_at: :asc)
+    @users = @family.users.excepted(current_user).order(created_at: :asc)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,8 @@ class User < ApplicationRecord
   validates :provider, presence: true
   validate :validate_avatar
 
+  scope :excepted, ->(user) { where.not(id: user) }
+
   def self.from_omniauth(auth_hash)
     provider = auth_hash[:provider]
     uid = auth_hash[:uid]


### PR DESCRIPTION
## Issue
- #178

## 概要
コードレビューで以下のようにアドバイスをいただいた。

https://github.com/siroemk/cotomemory/blob/ccf55a4aa0c69dc3e06f5cece080a8997354f076/app/controllers/families_controller.rb#L6

> @family.users.where.not(id: current_user.id).order(created_at: :asc) と書けますね
User クラスの scope にできると尚良しです

`where.not(id: current_user.id)`の部分を`User`クラスにscopeにした。