### PR TITLE
quotes_controllerでActiveRecordを活用できそうな箇所の修正

### DIFF
--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -17,10 +17,7 @@ class QuotesController < ApplicationController
 
   def show
     @comment = Comment.new
-    @comments = Comment
-                .where(quote_id: params[:id])
-                .includes(:user)
-                .order(created_at: :asc)
+    @comments = @quote.comments.includes(:user).order(created_at: :asc)
   end
 
   def new


### PR DESCRIPTION
## Issue
- #179

## 概要
コードレビューで以下のようにアドバイスをいただいた。

https://github.com/siroemk/cotomemory/blob/ccf55a4aa0c69dc3e06f5cece080a8997354f076/app/controllers/quotes_controller.rb#L21

> ここは @quote.comments.includes(:user).order(created_at: :asc) と書けますね

モデルの関連を使った書き方に修正しました。

- 参考
https://bootcamp.fjord.jp/articles/76