### PR TITLE
empty?からexists?に書き換えた

### DIFF
--- a/app/controllers/quotes_controller.rb
+++ b/app/controllers/quotes_controller.rb
@@ -5,7 +5,7 @@ class QuotesController < ApplicationController
   before_action :allow_show_quote_page_only_family, only: %i[show edit update destroy]
 
   def index
-    redirect_to new_child_path if current_user.family.children.empty?
+    redirect_to new_child_path unless current_user.family.children.exists?
 
     children_ids = current_user.family.children.pluck(:id)
     @quotes = Quote

--- a/app/views/children/index.html.slim
+++ b/app/views/children/index.html.slim
@@ -5,10 +5,7 @@
     | こどもの一覧
 
   #children
-    - if @children.empty?
-      p.text-sm.text-center
-        | こどもの情報が登録されていません。
-    - else
+    - if @children.exists?
       table.text-sm.w-full
         thead
           tr.bg-slate-50
@@ -20,5 +17,8 @@
               |
         tbody
           = render @children
+    - else
+      p.text-sm.text-center
+        | こどもの情報が登録されていません。
   .text-center.mt-10.mb-6
     = link_to 'こどもを追加する', new_child_path, class: 'primary-btn px-16'

--- a/app/views/families/show.html.slim
+++ b/app/views/families/show.html.slim
@@ -15,9 +15,9 @@
   .mx-2.mb-6
     h2.mb-6.pb-1.border-b-2.border-slate-200
       | 家族の一覧
-    - if @users.empty?
-      p.text-sm
-        | こどもの情報を共有している家族はいません。
-    - else
+    - if @users.exists?
       #users
       = render @users
+    - else
+      p.text-sm
+        | こどもの情報を共有している家族はいません。

--- a/app/views/quotes/index.html.slim
+++ b/app/views/quotes/index.html.slim
@@ -5,7 +5,7 @@
     = render @quotes
     = turbo_frame_tag "quotes-page-#{@quotes.next_page}", loading: :lazy, src: path_to_next_page(@quotes)
 
-- if @quotes.empty?
+- unless @quotes.exists?
   #first_message
     .mt-20.mb-2.bg-white.rounded.h-full
       p.text-center.mb-8


### PR DESCRIPTION
## Issue
- #180 

## 概要
コードレビューで以下のようにアドバイスをいただいた。

> empty? の代わりに exists? を使うと存在確認をSQLに任せられますね
> ここも exists? が使えますね

https://github.com/siroemk/cotomemory/blob/ccf55a4aa0c69dc3e06f5cece080a8997354f076/app/controllers/quotes_controller.rb#L8-L9
https://github.com/siroemk/cotomemory/blob/ccf55a4aa0c69dc3e06f5cece080a8997354f076/app/views/families/show.html.slim#L18
https://github.com/siroemk/cotomemory/blob/ccf55a4aa0c69dc3e06f5cece080a8997354f076/app/views/children/index.html.slim#L8

exists?に書き換えられる部分を修正した。
