### PR TITLE
複雑になっていた条件分岐を解消した

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -18,14 +18,13 @@ class CommentsController < ApplicationController
 
   def destroy
     @comment = @quote.comments.find(params[:id])
-    if current_user == @comment.user
-      @comment.destroy
-      respond_to do |format|
-        format.html { redirect_to quote_comments_path(@quote), notice: 'コメントを削除しました' }
-        format.turbo_stream { flash.now[:notice] = 'コメントを削除しました' }
-      end
-    else
-      render 'quotes/show', status: :unprocessable_entity
+
+    return render 'quotes/show', status: :unprocessable_entity unless current_user == @comment.user
+
+    @comment.destroy
+    respond_to do |format|
+      format.html { redirect_to quote_comments_path(@quote), notice: 'コメントを削除しました' }
+      format.turbo_stream { flash.now[:notice] = 'コメントを削除しました' }
     end
   end
 


### PR DESCRIPTION
## Issue
- #182 

## 概要
コードレビュー（https://bootcamp.fjord.jp/products/17942）で以下のようにアドバイスをいただいた。

https://github.com/siroemk/cotomemory/blob/ccf55a4aa0c69dc3e06f5cece080a8997354f076/app/controllers/comments_controller.rb#L21-L22
> 自分のコメントでなければ render して return する、という書き方にするとネストが減ってスッキリしそうです
