### PR TITLE
デザインレビューを受けてデザインを修正する（part2）

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -17,7 +17,7 @@
 .navbar {
   position: relative;
   width: 24px;
-  height: 32px;
+  height: 33px;
   margin-top: 12px;
 }
 
@@ -42,7 +42,7 @@
 }
 
 .navbar_icon::after {
-  bottom: 7px;
+  bottom: 8px;
 }
 
 .plus_icon {

--- a/app/views/children/_form.html.slim
+++ b/app/views/children/_form.html.slim
@@ -11,7 +11,7 @@
       class: 'pl-2 text-sm font-medium mb-2 block'
     = f.text_field :name,
       class: 'py-3 px-4 w-80 border-gray-300 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500 mb-6',
-      placeholder: 'たろう'
+      placeholder: 'はると、ひまり'
     = f.label :date_of_birth,
       class: 'pl-2 text-sm font-medium mb-2 block'
     = f.date_select :date_of_birth, { use_month_numbers: true, start_year: Time.zone.now.year, end_year: 2000 },

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -19,7 +19,6 @@ html.bg-slate-200
       - if current_page?(root_path)
         #flash
           = render 'layouts/flash'
-        = yield
       - else
         .pt-14
           #flash

--- a/app/views/quotes/_form.html.slim
+++ b/app/views/quotes/_form.html.slim
@@ -1,16 +1,20 @@
 = form_with model: quote, locale: true do |f|
-  - if f.object.errors.any?
-    ul
-      - f.object.errors.full_messages.each do |message|
-        li.text-rose-600.text-sm.mb-1.text-left
-          = message
+  .h-6
+    - if f.object.errors.any?
+      ul
+        - f.object.errors.full_messages.each do |message|
+          li.text-rose-600.text-sm.mb-1.text-left
+            = message
 
-  .mb-4.text-left
-    = f.collection_select :child_id, Child.where(family_id: current_user.family_id).order(:created_at), :id, :name, {},
-      class: 'py-3 px-4 w-40 border-gray-300 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500'
+  .mb-4.text-left.flex.items-center
+    .mr-3.5
+      = f.collection_select :child_id, Child.where(family_id: current_user.family_id).order(:created_at), :id, :name, {},
+        class: 'py-3 px-4 w-48 border-gray-300 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500'
+    .text-slate-600
+      p の名言を保存する
   .mb-4
     = f.text_area :content,
       class: 'py-3 px-4 block w-full h-32 border-gray-300 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500'
   .text-right
     = f.submit '保存する',
-      class: 'bg-primary hover:bg-opacity-75 transition py-2 px-2 my-4 w-40 rounded-full font-bold text-white inline-block'
+      class: 'bg-primary hover:bg-opacity-75 transition py-2 px-2 mt-4 w-40 rounded-full font-bold text-white inline-block'

--- a/app/views/quotes/_quote.html.slim
+++ b/app/views/quotes/_quote.html.slim
@@ -1,27 +1,28 @@
-= turbo_frame_tag quote do
-  .p-4.border-b.relative
-    .flex.pb-2
-      p.text-slate-600.font-semibold
-        = quote.child.name
-      p.text-slate-600.font-semibold
-        = convert_to_age(quote.child.date_of_birth)
-      p.text-sm.text-slate-400
-        = l quote.created_at, format: :long
-      - if current_user == quote.user
-        .ml-auto.flex.mr-1
-          p.text-slate-400
-            = link_to '編集', edit_quote_path(quote), class: 'edit-btn text-sm mr-3'
-          p.text-slate-400
-            = link_to '削除', quote, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-sm'
+.border-b
+  = turbo_frame_tag quote do
+    .p-4.relative
+      .flex.flex-wrap.pb-2
+        p.text-slate-600.font-semibold
+          = quote.child.name
+        p.text-slate-600.font-semibold
+          = convert_to_age(quote.child.date_of_birth)
+        p.text-sm.text-slate-400
+          = l quote.created_at, format: :long
+        - if current_user == quote.user
+          .ml-auto.flex.mr-1
+            p.text-slate-400
+              = link_to '編集', edit_quote_path(quote), class: 'edit-btn text-sm mr-3'
+            p.text-slate-400
+              = link_to '削除', quote, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-sm'
 
-    p.leading-relaxed.text-slate-800
-      = link_to quote_path(quote.id), data: { turbo: false }
-        = quote.content
+      p.leading-relaxed.text-slate-800
+        = link_to quote_path(quote.id), data: { turbo: false }
+          = quote.content
 
-    .flex.justify-end
-      = link_to quote_path(quote.id), data: { turbo: false }, class: 'pr-1'
-        .flex
-          .pr-1
-            = image_tag 'comment-icon.png', alt: 'コメントの画像', class: 'h-4'
-          p.text-slate-500.text-xs
-            = quote.comments.count
+      .flex.justify-end
+        = link_to quote_path(quote.id), data: { turbo: false }, class: 'pr-1'
+          .flex
+            .pr-1
+              = image_tag 'comment-icon.png', alt: 'コメントの画像', class: 'h-4'
+            p.text-slate-500.text-xs
+              = quote.comments.count

--- a/app/views/quotes/_quote.html.slim
+++ b/app/views/quotes/_quote.html.slim
@@ -9,11 +9,9 @@
         p.text-sm.text-slate-400
           = l quote.created_at, format: :long
         - if current_user == quote.user
-          .ml-auto.flex.mr-1
+          .ml-auto
             p.text-slate-400
-              = link_to '編集', edit_quote_path(quote), class: 'edit-btn text-sm mr-3'
-            p.text-slate-400
-              = link_to '削除', quote, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-sm'
+              = link_to '編集', edit_quote_path(quote), class: 'text-sm'
 
       p.leading-relaxed.text-slate-800
         = link_to quote_path(quote.id), data: { turbo: false }

--- a/app/views/quotes/edit.html.slim
+++ b/app/views/quotes/edit.html.slim
@@ -1,5 +1,5 @@
 = turbo_frame_tag @quote do
-  .py-4.px-2.mb-2.bg-white.rounded
+  .py-4.px-4.bg-white.rounded
     = form_with model: @quote, locale: true do |f|
       - if @quote.errors.any?
         ul
@@ -7,9 +7,10 @@
             li.text-rose-600.text-sm.mb-1.text-left
               = message
 
-      .mb-4.text-left
+      .mb-4.text-left.flex.justify-between.items-center
         = f.collection_select :child_id, Child.where(family_id: current_user.family_id).order(:created_at), :id, :name, {},
           class: 'py-3 px-4 w-40 border-gray-300 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500'
+        = link_to 'この名言を削除する', @quote, data: { turbo_method: :delete, turbo_confirm: '本当に削除しますか？' }, class: 'text-xs text-gray-700 hover:underline'
       .mb-4
         = f.text_area :content,
           class: 'py-3 px-4 block w-full h-32 border-gray-300 rounded-md text-sm focus:border-blue-500 focus:ring-blue-500'

--- a/app/views/quotes/index.html.slim
+++ b/app/views/quotes/index.html.slim
@@ -20,7 +20,7 @@
         .hidden.fixed.overlay.top-0.left-0.w-screen.h-screen.bg-gray-300.bg-opacity-70.z-20  data-modal-target='modal' data-action='turbo:frame-load->modal#open turbo:submit-end->modal#close'
           .absolute.top-1/2.left-1/2.transform.w-96.h-96.bg-white.p-6.rounded-lg
             .text-right
-              button.text-3xl.text-slate-500.mb-2 data-action='click->modal#close'
+              button.text-3xl.text-slate-500 data-action='click->modal#close'
                 | ×
               = turbo_frame_tag 'new_quote'
       = image_tag 'read_book.png', alt: '本を読んでいるこどもの画像', class: 'w-60 m-auto max-w-screen-sm'
@@ -31,6 +31,6 @@ div data-controller='modal'
   .hidden.fixed.top-0.left-0.w-screen.h-screen.bg-gray-300.bg-opacity-70.z-50 data-modal-target='modal' data-action='turbo:frame-load->modal#open turbo:submit-end->modal#close'
     .absolute.top-1/2.left-1/2.transform.w-96.h-96.bg-white.p-6.rounded-lg
       .text-right
-        button.text-3xl.text-slate-500.mb-2 data-action='click->modal#close'
+        button.text-3xl.text-slate-500 data-action='click->modal#close'
           | ×
         = turbo_frame_tag 'new_quote'

--- a/app/views/shared/_header.html.slim
+++ b/app/views/shared/_header.html.slim
@@ -1,4 +1,4 @@
-.h-14.px-6.flex.justify-between.bg-slate-50.w-full.border-b.border-slate-200.fixed.z-10.max-w-screen-sm
+.h-14.px-4.flex.justify-between.bg-slate-50.w-full.border-b.border-slate-200.fixed.z-10.max-w-screen-sm
   = link_to root_path
     .flex.items-center.h-14
       = image_tag 'logo.png', alt: 'Cotomemoryのロゴ画像', class: 'w-36'

--- a/spec/system/quotes_spec.rb
+++ b/spec/system/quotes_spec.rb
@@ -35,20 +35,18 @@ RSpec.describe 'Quotes', type: :system do
     end
 
     context '名言を登録したユーザーの場合' do
-      it '名言の編集と削除ボタンが表示される' do
+      it '名言の編集ボタンが表示される' do
         quote = create(:quote, child:, user:)
         visit quotes_path
         expect(page).to have_link('編集', href: "/quotes/#{quote.id}/edit")
-        expect(page).to have_link('削除', href: "/quotes/#{quote.id}")
       end
     end
 
     context '名言を登録していないユーザーの場合' do
-      it '名言の編集と削除ボタンが表示されない' do
+      it '名言の編集ボタンが表示されない' do
         quote = create(:quote, child:)
         visit quotes_path
         expect(page).to_not have_link('編集', href: "/quotes/#{quote.id}/edit")
-        expect(page).to_not have_link('削除', href: "/quotes/#{quote.id}")
       end
     end
   end
@@ -125,11 +123,14 @@ RSpec.describe 'Quotes', type: :system do
 
   describe '#destroy' do
     it '名言を削除できること' do
-      create(:quote, content: 'おつきさまがついてくるよ', child:, user:)
+      quote = create(:quote, content: 'おつきさまがついてくるよ', child:, user:)
       visit quotes_path
       expect(page).to have_content 'おつきさまがついてくるよ'
 
-      click_on '削除'
+      within("#quote_#{quote.id}") do
+        click_on '編集'
+      end
+      click_on 'この名言を削除する'
       expect(page.accept_confirm).to eq('本当に削除しますか？')
       expect(page).to have_content '名言を削除しました'
 


### PR DESCRIPTION
## Issue
- #172

## 修正した箇所
 - 名言のフォームに「〇〇の名言を保存する」と表示する
 - ヘッダーのバーがずれている
 - 削除ボタンは編集画面に移動させる
 - 名前の文字数が多い場合は画面が崩れてしまう
 - コンテンツの左端とロゴの左端を揃える
 - こどもの情報を登録するページでplaceholderに女の子の名前も書いておく
 - yieldが重複していたので一つを削除した