### PR TITLE
meta titleに「コトメモリー」を追加した

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -3,15 +3,15 @@
 module ApplicationHelper
   def default_meta_tags
     {
-      site: 'Cotomemory コトバのキオクをキロクしよう',
+      site: 'Cotomemory コトメモリー',
       reverse: true,
       charset: 'utf-8',
-      description: 'Cotomemoryは子供の可愛い名言を簡単に記録できるサービスです。家族と名言を共有することができます。',
-      keywords: '子育て, 子供, こども, 名言',
+      description: 'Cotomemory（コトメモリー）は子供の可愛い名言を簡単に記録できるサービスです。家族と名言を共有することができます。',
+      keywords: 'コトメモリー, cotomemory, 子育て, 子供, こども, 名言, こどもの名言',
       og: {
         title: :title,
         type: 'website',
-        site_name: 'Cotomemory',
+        site_name: 'Cotomemory コトメモリー',
         description: :description,
         image: image_url('ogp.png'),
         url: 'https://cotomemory.com'

--- a/app/views/children/edit.html.slim
+++ b/app/views/children/edit.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: 'こどもの編集', reverse: true
+- set_meta_tags title: 'こどもの編集', reverse: true
 
 .px-4
   h1.title

--- a/app/views/children/index.html.slim
+++ b/app/views/children/index.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: 'こどもの一覧', reverse: true
+- set_meta_tags title: 'こどもの一覧', reverse: true
 
 .px-4
   h1.title

--- a/app/views/children/new.html.slim
+++ b/app/views/children/new.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: 'こどもの追加登録', reverse: true
+- set_meta_tags title: 'こどもの追加登録', reverse: true
 
 .px-4
   h1.title

--- a/app/views/families/show.html.slim
+++ b/app/views/families/show.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: '家族を招待する', reverse: true
+- set_meta_tags title: '家族を招待する', reverse: true
 
 .px-4
   h1.title

--- a/app/views/quotes/index.html.slim
+++ b/app/views/quotes/index.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: '名言一覧', reverse: true
+- set_meta_tags title: '名言一覧', reverse: true
 
 #quotes
   = turbo_frame_tag "quotes-page-#{@quotes.current_page}"

--- a/app/views/top/privacy.html.slim
+++ b/app/views/top/privacy.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: 'プライバシーポリシー', reverse: true
+- set_meta_tags title: 'プライバシーポリシー', reverse: true
 
 .px-4
   h1.title

--- a/app/views/top/terms.html.slim
+++ b/app/views/top/terms.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: '利用規約', reverse: true
+- set_meta_tags title: '利用規約', reverse: true
 
 .px-4
   h1.title

--- a/app/views/users/edit.html.slim
+++ b/app/views/users/edit.html.slim
@@ -1,4 +1,4 @@
-- set_meta_tags site: 'Cotomemory', title: 'アカウント設定', reverse: true
+- set_meta_tags title: 'アカウント設定', reverse: true
 
 .px-4
   h1.title


### PR DESCRIPTION
## Issue
- #210

meta titleにコトメモリー（カタカナ表記）が入っていなかったので追加しました。